### PR TITLE
nrfx HAL: Add nrf_clock_is_running

### DIFF
--- a/src/nrfx/hal/nrf_clock.h
+++ b/src/nrfx/hal/nrf_clock.h
@@ -80,6 +80,22 @@ extern "C" {
 #define NRF_CLOCK_HAS_CALIBRATION 0
 #endif // defined(CLOCK_CTIV_CTIV_Msk) || defined(__NRFX_DOXYGEN__)
 
+#if (defined(CLOCK_INTENSET_HFCLK192MSTARTED_Msk) && !defined(NRF5340_XXAA_NETWORK)) \
+    || defined(__NRFX_DOXYGEN__)
+/** @brief Presence of the 192 MHz clock. */
+#define NRF_CLOCK_HAS_HFCLK192M 1
+#else
+#define NRF_CLOCK_HAS_HFCLK192M 0
+#endif
+
+#if (defined(CLOCK_INTENSET_HFCLKAUDIOSTARTED_Msk) && !defined(NRF5340_XXAA_NETWORK)) \
+    || defined(__NRFX_DOXYGEN__)
+/** @brief Presence of the Audio clock. */
+#define NRF_CLOCK_HAS_HFCLKAUDIO 1
+#else
+#define NRF_CLOCK_HAS_HFCLKAUDIO 0
+#endif
+
 /**
  * @brief Low-frequency clock sources.
  * @details Used by LFCLKSRC, LFCLKSTAT, and LFCLKSRCCOPY registers.
@@ -130,6 +146,19 @@ typedef enum
     NRF_CLOCK_HFCLK_HIGH_ACCURACY = CLOCK_HFCLKSTAT_SRC_HFXO /**< External 32 MHz crystal oscillator. */
 #endif
 } nrf_clock_hfclk_t;
+
+/** @brief Clock domains. */
+typedef enum
+{
+    NRF_CLOCK_DOMAIN_LFCLK,
+    NRF_CLOCK_DOMAIN_HFCLK,
+#if NRF_CLOCK_HAS_HFCLK192M
+    NRF_CLOCK_DOMAIN_HFCLK192M,
+#endif
+#if NRF_CLOCK_HAS_HFCLKAUDIO
+    NRF_CLOCK_DOMAIN_HFCLKAUDIO,
+#endif
+} nrf_clock_domain_t;
 
 /**
  * @brief Trigger status of task LFCLKSTART/HFCLKSTART.
@@ -280,6 +309,61 @@ static inline nrf_clock_lfclk_t nrf_clock_lf_src_get(NRF_CLOCK_Type const * p_re
 {
     return (nrf_clock_lfclk_t)(p_reg->LFCLKSRC);
 }
+
+nrf_clock_is_running(NRF_CLOCK_Type const * p_reg, nrf_clock_domain_t domain,
+                    void * clk_src)
+{
+    switch (domain)
+    {
+        case NRF_CLOCK_DOMAIN_LFCLK:
+            if (clk_src != NULL)
+            {
+                (*(uint32_t *)clk_src) = ((p_reg->LFCLKSTAT & CLOCK_LFCLKSTAT_SRC_Msk)
+                                          >> CLOCK_LFCLKSTAT_SRC_Pos);
+            }
+            if ((p_reg->LFCLKSTAT & CLOCK_LFCLKSTAT_STATE_Msk)
+                >> CLOCK_LFCLKSTAT_STATE_Pos)
+            {
+                return true;
+            }
+            break;
+        case NRF_CLOCK_DOMAIN_HFCLK:
+            if (clk_src != NULL)
+            {
+                (*(uint32_t *)clk_src) = ((p_reg->HFCLKSTAT & CLOCK_HFCLKSTAT_SRC_Msk)
+                                          >> CLOCK_HFCLKSTAT_SRC_Pos);
+            }
+            if ((p_reg->HFCLKSTAT & CLOCK_HFCLKSTAT_STATE_Msk)
+                >> CLOCK_HFCLKSTAT_STATE_Pos)
+            {
+                return true;
+            }
+            break;
+#if NRF_CLOCK_HAS_HFCLK192M
+        case NRF_CLOCK_DOMAIN_HFCLK192M:
+            if (clk_src != NULL)
+            {
+                (*(uint32_t *)clk_src) = ((p_reg->HFCLK192MSTAT & CLOCK_HFCLK192MSTAT_SRC_Msk)
+                                          >> CLOCK_HFCLK192MSTAT_SRC_Pos);
+            }
+            if ((p_reg->HFCLK192MSTAT & CLOCK_HFCLK192MSTAT_STATE_Msk)
+                >> CLOCK_HFCLK192MSTAT_STATE_Pos)
+            {
+                return true;
+            }
+            break;
+#endif
+#if NRF_CLOCK_HAS_HFCLKAUDIO
+        case NRF_CLOCK_DOMAIN_HFCLKAUDIO:
+            return (p_reg->HFCLKAUDIOSTAT & CLOCK_HFCLKAUDIOSTAT_STATE_Msk) ==
+                   CLOCK_HFCLKAUDIOSTAT_STATE_Msk;
+#endif
+        default:
+            return false;
+    }
+    return false;
+}
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Added call that is now used by the clock control driver.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>