### PR TITLE
nrfx: Modify inclusions to allow use of drivers from nrfx

### DIFF
--- a/src/nrfx/drivers/nrfx_common.h
+++ b/src/nrfx/drivers/nrfx_common.h
@@ -50,6 +50,16 @@
 extern "C" {
 #endif
 
+/*
+ * Suppress use of anomaly workarounds in nrfx drivers that would directly
+ * access hardware registers.
+ */
+#define USE_WORKAROUND_FOR_ANOMALY_132 0
+
+#ifndef __STATIC_INLINE
+#define __STATIC_INLINE static inline
+#endif
+
 #ifndef NRFX_STATIC_INLINE
 #ifdef NRFX_DECLARE_ONLY
 #define NRFX_STATIC_INLINE
@@ -209,10 +219,37 @@ NRF_STATIC_INLINE IRQn_Type nrfx_get_irq_number(void const * p_reg)
     return (IRQn_Type)NRFX_IRQ_NUMBER_GET(p_reg);
 }
 
+/**
+ * @brief IRQ handler type.
+ */
+typedef void (*nrfx_irq_handler_t)(void);
+
+/**@brief Macro for waiting until condition is met.
+ *
+ * @param[in]  condition Condition to meet.
+ * @param[in]  attempts  Maximum number of condition checks. Must not be 0.
+ * @param[in]  delay_us  Delay between consecutive checks, in microseconds.
+ * @param[out] result    Boolean variable to store the result of the wait process.
+ *                       Set to true if the condition is met or false otherwise.
+ */
+#define NRFX_WAIT_FOR(condition, attempts, delay_us, result) \
+do {                                                         \
+    result =  false;                                         \
+    uint32_t remaining_attempts = (attempts);                \
+    do {                                                     \
+           if (condition)                                    \
+           {                                                 \
+               result =  true;                               \
+               break;                                        \
+           }                                                 \
+           NRFX_DELAY_US(delay_us);                          \
+    } while (--remaining_attempts);                          \
+} while(0)
+
 /** @} */
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif // NRFX_COMMON_H__
+#endif // BS_NRFX_COMMON_H__

--- a/src/nrfx/hal/nrf_ccm.h
+++ b/src/nrfx/hal/nrf_ccm.h
@@ -42,8 +42,7 @@
 #ifndef BS_NRF_CCM_H__
 #define BS_NRF_CCM_H__
 
-#include "nrf_soc_if.h"
-#include "../drivers/nrfx_common.h"
+#include <nrfx.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/nrfx/hal/nrf_clock.h
+++ b/src/nrfx/hal/nrf_clock.h
@@ -42,8 +42,7 @@
 #ifndef BS_NRF_CLOCK_H__
 #define BS_NRF_CLOCK_H__
 
-#include "nrf_soc_if.h"
-#include "../drivers/nrfx_common.h"
+#include <nrfx.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/nrfx/hal/nrf_clock.h
+++ b/src/nrfx/hal/nrf_clock.h
@@ -381,6 +381,18 @@ NRF_STATIC_INLINE bool nrf_clock_event_check(NRF_CLOCK_Type const * p_reg, nrf_c
     return (bool)*((volatile uint32_t *)((uint8_t *)p_reg + event));
 }
 
+NRF_STATIC_INLINE uint32_t nrf_clock_task_address_get(NRF_CLOCK_Type const * p_reg,
+                                                      nrf_clock_task_t       task)
+{
+    return 0;
+}
+
+NRF_STATIC_INLINE uint32_t nrf_clock_event_address_get(NRF_CLOCK_Type const * p_reg,
+                                                      nrf_clock_event_t       event)
+{
+    return 0;
+}
+
 NRF_STATIC_INLINE bool nrf_clock_start_task_check(NRF_CLOCK_Type const * p_reg,
                                                   nrf_clock_domain_t     domain)
 {

--- a/src/nrfx/hal/nrf_ecb.h
+++ b/src/nrfx/hal/nrf_ecb.h
@@ -41,8 +41,7 @@
 #ifndef BS_NRF_ECB_H__
 #define BS_NRF_ECB_H__
 
-#include "nrf_soc_if.h"
-#include "../drivers/nrfx_common.h"
+#include <nrfx.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/nrfx/hal/nrf_gpio.h
+++ b/src/nrfx/hal/nrf_gpio.h
@@ -6,6 +6,6 @@
 #ifndef BS_NRF_GPIO_H__
 #define BS_NRF_GPIO_H__
 
-#include "../drivers/nrfx_common.h"
+#include <nrfx.h>
 
 #endif /* BS_NRF_GPIO_H__ */

--- a/src/nrfx/hal/nrf_gpiote.h
+++ b/src/nrfx/hal/nrf_gpiote.h
@@ -6,6 +6,6 @@
 #ifndef BS_NRF_GPIOTE_H__
 #define BS_NRF_GPIOTE_H__
 
-#include "../drivers/nrfx_common.h"
+#include <nrfx.h>
 
 #endif /* BS_NRF_TIMER_H__ */

--- a/src/nrfx/hal/nrf_power.h
+++ b/src/nrfx/hal/nrf_power.h
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  *
  */
-#include "../drivers/nrfx_common.h"
+#include <nrfx.h>

--- a/src/nrfx/hal/nrf_power.h
+++ b/src/nrfx/hal/nrf_power.h
@@ -5,3 +5,8 @@
  *
  */
 #include <nrfx.h>
+
+NRF_STATIC_INLINE uint32_t nrf_power_int_enable_get(NRF_POWER_Type const * p_reg)
+{
+    return 0;
+}

--- a/src/nrfx/hal/nrf_ppi.h
+++ b/src/nrfx/hal/nrf_ppi.h
@@ -42,8 +42,7 @@
 #ifndef BS_NRF_PPI_H__
 #define BS_NRF_PPI_H__
 
-#include "nrf_soc_if.h"
-#include "../drivers/nrfx_common.h"
+#include <nrfx.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/nrfx/hal/nrf_radio.h
+++ b/src/nrfx/hal/nrf_radio.h
@@ -42,8 +42,7 @@
 #ifndef BS_NRF_RADIO_H__
 #define BS_NRF_RADIO_H__
 
-#include "nrf_soc_if.h"
-#include "../drivers/nrfx_common.h"
+#include <nrfx.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/nrfx/hal/nrf_rng.h
+++ b/src/nrfx/hal/nrf_rng.h
@@ -42,8 +42,7 @@
 #ifndef BS_NRF_RNG_H__
 #define BS_NRF_RNG_H__
 
-#include "nrf_soc_if.h"
-#include "../drivers/nrfx_common.h"
+#include <nrfx.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/nrfx/hal/nrf_rtc.h
+++ b/src/nrfx/hal/nrf_rtc.h
@@ -42,8 +42,7 @@
 #ifndef BS_NRF_RTC_H__
 #define BS_NRF_RTC_H__
 
-#include "nrf_soc_if.h"
-#include "../drivers/nrfx_common.h"
+#include <nrfx.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/nrfx/hal/nrf_soc_if.h
+++ b/src/nrfx/hal/nrf_soc_if.h
@@ -95,8 +95,6 @@ extern void __SEV(void);
 extern void NVIC_SetPendingIRQ(IRQn_Type IRQn);
 extern void NVIC_ClearPendingIRQ(IRQn_Type IRQn);
 
-#define NRFX_ASSERT(...)
-
 #ifdef __cplusplus
 }
 #endif

--- a/src/nrfx/hal/nrf_temp.h
+++ b/src/nrfx/hal/nrf_temp.h
@@ -6,6 +6,6 @@
 #ifndef BS_NRF_TEMP_H__
 #define BS_NRF_TEMP_H__
 
-#include "../drivers/nrfx_common.h"
+#include <nrfx.h>
 
 #endif /* BS_NRF_TEMP_H__ */

--- a/src/nrfx/hal/nrf_timer.h
+++ b/src/nrfx/hal/nrf_timer.h
@@ -42,8 +42,7 @@
 #ifndef BS_NRF_TIMER_H__
 #define BS_NRF_TIMER_H__
 
-#include "nrf_soc_if.h"
-#include "../drivers/nrfx_common.h"
+#include <nrfx.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Modify the way that files are included, to make it possible to override
certain nrfx files (in particular, HAL and MDK) with their modified
versions from this repository while using other ones (like drivers)
in their original form, directly from the hal_nordic module.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>
Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>