### PR TITLE
Implement EGU register for nrf52 family

### DIFF
--- a/src/nrfx/hal/nrf_egu.c
+++ b/src/nrfx/hal/nrf_egu.c
@@ -1,0 +1,176 @@
+/** Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Note that the function prototypes are taken from the NRFx HAL
+ */
+
+ #if 1
+
+#include "hal/nrf_egu.h"
+#include "bs_tracing.h"
+#include "NRF_EGU.h"
+#include <kernel.h>
+#include <irq_ctrl.h>
+
+uint32_t nrf_egu_channel_count(NRF_EGU_Type const *p_reg)
+{
+	return 16;
+}
+
+static int reg_to_irq(NRF_EGU_Type *p_reg)
+{
+	extern NRF_EGU_Type NRF_EGU_regs[6];
+	size_t raw_offset = (size_t)p_reg - (size_t)(&NRF_EGU_regs[0]);
+	size_t id = raw_offset / sizeof(NRF_EGU_Type);
+
+	switch (id) {
+	case 0: return SWI0_EGU0_IRQn; break;
+	case 1: return SWI1_EGU1_IRQn; break;
+	case 2: return SWI2_EGU2_IRQn; break;
+	case 3: return SWI3_EGU3_IRQn; break;
+	case 4: return SWI4_EGU4_IRQn; break;
+	case 5: return SWI5_EGU5_IRQn; break;
+	}
+	return 0xff;
+}
+
+static uint32_t task_to_id(nrf_egu_task_t task)
+{
+	return task / sizeof(((NRF_EGU_Type *)NULL)->TASKS_TRIGGER[0]);
+}
+
+void nrf_egu_task_trigger(NRF_EGU_Type *p_reg, nrf_egu_task_t egu_task)
+{
+	p_reg->EVENTS_TRIGGERED[task_to_id(egu_task)] = 1;
+	if (p_reg->INTEN & BIT(task_to_id(egu_task))) {
+		hw_irq_ctrl_set_irq(reg_to_irq(p_reg));
+	}
+}
+
+uint32_t nrf_egu_task_address_get(NRF_EGU_Type const *p_reg,
+				  nrf_egu_task_t egu_task)
+{
+	return (uint32_t)p_reg + egu_task;
+}
+
+nrf_egu_task_t nrf_egu_trigger_task_get(uint8_t channel)
+{
+	return (nrf_egu_task_t)offsetof(NRF_EGU_Type, TASKS_TRIGGER[channel]);
+}
+
+bool nrf_egu_event_check(NRF_EGU_Type const *p_reg, nrf_egu_event_t egu_event)
+{
+	return *((volatile uint32_t *)((uint8_t *)p_reg + (uint32_t)egu_event));
+}
+
+void nrf_egu_event_clear(NRF_EGU_Type *p_reg, nrf_egu_event_t egu_event)
+{
+	// clear selected event
+	*((volatile uint32_t *)((uint8_t *)p_reg + (uint32_t)egu_event)) = 0x0UL;
+	// check if all events are cleared
+	for (uint8_t i = 0; i < 16; i++) {
+		if (p_reg->EVENTS_TRIGGERED[i]) {
+			return; // if there is still pending event do not clear irq
+		}
+	}
+	hw_irq_ctrl_clear_irq(reg_to_irq(p_reg));
+}
+
+uint32_t nrf_egu_event_address_get(NRF_EGU_Type const *p_reg,
+				   nrf_egu_event_t egu_event)
+{
+	return (uint32_t)((uint8_t *)p_reg + (uint32_t)egu_event);
+}
+
+nrf_egu_event_t nrf_egu_triggered_event_get(uint8_t channel)
+{
+	return (nrf_egu_event_t)NRFX_OFFSETOF(NRF_EGU_Type, EVENTS_TRIGGERED[channel]);
+}
+
+void nrf_egu_int_enable(NRF_EGU_Type *p_reg, uint32_t mask)
+{
+	p_reg->INTEN |= mask;
+	bool found = false;
+	for (uint8_t i = 0; i < 16; i++) {
+		if ((p_reg->INTEN & BIT(i)) && p_reg->EVENTS_TRIGGERED[i]) {
+			found = true;
+			break;
+		}
+	}
+	if (found) {
+		hw_irq_ctrl_set_irq(reg_to_irq(p_reg));
+	}
+}
+
+uint32_t nrf_egu_int_enable_check(NRF_EGU_Type const *p_reg, uint32_t mask)
+{
+	return p_reg->INTEN & mask;
+}
+
+void nrf_egu_int_disable(NRF_EGU_Type *p_reg, uint32_t mask)
+{
+	p_reg->INTEN &= ~mask;
+}
+
+nrf_egu_int_mask_t nrf_egu_channel_int_get(uint8_t channel)
+{
+	return (nrf_egu_int_mask_t)((uint32_t) (EGU_INTENSET_TRIGGERED0_Msk << channel));
+}
+
+#if defined(DPPI_PRESENT) || defined(__NRFX_DOXYGEN__)
+
+/**
+ * @brief Function for setting the subscribe configuration for a given
+ *        EGU task.
+ *
+ * @param[in] p_reg   Pointer to the structure of registers of the peripheral.
+ * @param[in] task    Task for which to set the configuration.
+ * @param[in] channel Channel through which to subscribe events.
+ */
+void nrf_egu_subscribe_set(NRF_EGU_Type *p_reg, nrf_egu_task_t task,
+			   uint8_t channel)
+{
+	// bs_trace_debug_line_time(0, "%s\n", __func__);
+}
+
+/**
+ * @brief Function for clearing the subscribe configuration for a given
+ *        EGU task.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] task  Task for which to clear the configuration.
+ */
+void nrf_egu_subscribe_clear(NRF_EGU_Type *p_reg, nrf_egu_task_t task)
+{
+	// bs_trace_debug_line_time(0, "%s\n", __func__);
+}
+
+/**
+ * @brief Function for setting the publish configuration for a given
+ *        EGU event.
+ *
+ * @param[in] p_reg   Pointer to the structure of registers of the peripheral.
+ * @param[in] event   Event for which to set the configuration.
+ * @param[in] channel Channel through which to publish the event.
+ */
+void nrf_egu_publish_set(NRF_EGU_Type *p_reg, nrf_egu_event_t event,
+			 uint8_t channel)
+{
+	// bs_trace_debug_line_time(0, "%s\n", __func__);
+}
+
+/**
+ * @brief Function for clearing the publish configuration for a given
+ *        EGU event.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] event Event for which to clear the configuration.
+ */
+void nrf_egu_publish_clear(NRF_EGU_Type *p_reg, nrf_egu_event_t event)
+{
+	// bs_trace_debug_line_time(0, "%s\n", __func__);
+}
+
+#endif // defined(DPPI_PRESENT) || defined(__NRFX_DOXYGEN__)
+#endif

--- a/src/nrfx/mdk_replacements/nrf_bsim_redef.h
+++ b/src/nrfx/mdk_replacements/nrf_bsim_redef.h
@@ -88,6 +88,20 @@ extern NRF_EGU_Type NRF_EGU_regs[6];
 #undef NRF_EGU5_BASE
 #define NRF_EGU5_BASE                     (&NRF_EGU_regs[5])
 
+extern NRF_EGU_Type NRF_EGU_regs[];
+#undef NRF_EGU0_BASE
+#define NRF_EGU0_BASE                     (&NRF_EGU_regs[0])
+#undef NRF_EGU1_BASE
+#define NRF_EGU1_BASE                     (&NRF_EGU_regs[1])
+#undef NRF_EGU2_BASE
+#define NRF_EGU2_BASE                     (&NRF_EGU_regs[2])
+#undef NRF_EGU3_BASE
+#define NRF_EGU3_BASE                     (&NRF_EGU_regs[3])
+#undef NRF_EGU4_BASE
+#define NRF_EGU4_BASE                     (&NRF_EGU_regs[4])
+#undef NRF_EGU5_BASE
+#define NRF_EGU5_BASE                     (&NRF_EGU_regs[5])
+
 /*
  * Redefine the peripheral pointers
  */


### PR DESCRIPTION
initial implementation of EGU register for nrf52 family SoCs

Tests for this feature were added to zephyr by https://github.com/zephyrproject-rtos/zephyr/pull/48548